### PR TITLE
Added a `write_buf` function to write one chunk of data directly

### DIFF
--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -66,6 +66,22 @@ size_t HardwareBLESerial::write(uint8_t byte) {
   return 1;
 }
 
+size_t HardwareBLESerial::write_buf(uint8_t* bytes, size_t len) {
+  if (this->transmitCharacteristic.subscribed() == false) {
+    return 0;
+  }
+  // start by clearing the transmit buffer
+  this->transmitBufferLength = 0;
+  memset(this->transmitBuffer, 0, sizeof(this->transmitBuffer));
+
+  // copy the bytes to the transmit buffer
+  const auto dataLen {min(len, sizeof(this->transmitBuffer))};
+  memcpy(this->transmitBuffer, bytes, dataLen);
+  this->transmitBufferLength = dataLen;
+  flush();
+  return 1;
+}
+
 void HardwareBLESerial::flush() {
   if (this->transmitBufferLength > 0) {
     this->transmitCharacteristic.setValue(this->transmitBuffer, this->transmitBufferLength);

--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -70,9 +70,11 @@ size_t HardwareBLESerial::write_buf(uint8_t* bytes, size_t len) {
   if (this->transmitCharacteristic.subscribed() == false) {
     return 0;
   }
-  // start by clearing the transmit buffer
-  this->transmitBufferLength = 0;
-  memset(this->transmitBuffer, 0, sizeof(this->transmitBuffer));
+
+  // the transmit buffer is not empty, flush it
+  if (this->transmitBufferLength > 0) {
+    flush();
+  }
 
   // copy the bytes to the transmit buffer
   const auto dataLen {min(len, sizeof(this->transmitBuffer))};

--- a/src/HardwareBLESerial.h
+++ b/src/HardwareBLESerial.h
@@ -14,8 +14,13 @@ Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://app
 #include <Arduino.h>
 #include <ArduinoBLE.h>
 
-#define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 32
-#define BLE_SERIAL_RECEIVE_BUFFER_SIZE 256
+#ifndef BLE_ATTRIBUTE_MAX_VALUE_LENGTH
+  #define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 32
+#endif
+
+#ifndef BLE_SERIAL_RECEIVE_BUFFER_SIZE
+  #define BLE_SERIAL_RECEIVE_BUFFER_SIZE 256
+#endif
 
 template<size_t N> class ByteRingBuffer {
   private:

--- a/src/HardwareBLESerial.h
+++ b/src/HardwareBLESerial.h
@@ -14,7 +14,7 @@ Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://app
 #include <Arduino.h>
 #include <ArduinoBLE.h>
 
-#define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 20
+#define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 32
 #define BLE_SERIAL_RECEIVE_BUFFER_SIZE 256
 
 template<size_t N> class ByteRingBuffer {
@@ -68,6 +68,7 @@ class HardwareBLESerial {
     int peek();
     int read();
     size_t write(uint8_t byte);
+    size_t write_buf(uint8_t* bytes, size_t length);
     void flush();
 
     size_t availableLines();


### PR DESCRIPTION
Since the buffer size can be overridden, this could help cases where someone needs to send a small chunk of data without breaking it up across multiple messages. I needed this to reduce latency