### PR TITLE
STM32WB5x support, arduino Print class & host capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Registers the BLE UART service with ArduinoBLE, and sets it as the one service w
 
 This requires ArduinoBLE to be initialized beforehand. Afterwards, you must also tell ArduinoBLE to start actually broadcasting, using `BLE.advertise()`. For a helper function that does everything ArduinoBLE-related for you, see `HardwareBLESerial::beginAndSetupBLE`.
 
+Note (2023,Thijs): HardwareBLESerialHost does not have a begin() function (only beginAndSetupBLE()). This may change in the future, not sure.
+
 ### `void HardwareBLESerial::poll()`
 
 Performs internal BLE-related housekeeping tasks. Must be called regularly to ensure BLE state is kept up to date.
@@ -164,35 +166,9 @@ Copies the next line available for reading into `buffer` (or the first `bufferSi
 
 Returns the number of characters copied from the line, so between 0 and `bufferSize - 1`. If there was no next line, then consider that as 0 characters being copied.
 
-### `size_t HardwareBLESerial::print(const char *str)`, `size_t HardwareBLESerial::println(const char *str)`
+### `size_t HardwareBLESerial::print()`, `size_t HardwareBLESerial::println()`
 
-Writes a null-terminated string `str` to the transmit buffer, where it'll queue up until the buffer is flushed (usually within 100 milliseconds).
-
-Returns the number of bytes that were sent to the BLE central device (0 if there is no BLE central device connected).
-
-### `size_t HardwareBLESerial::print(char value)`, `size_t HardwareBLESerial::println(char value)`
-
-Writes a single char `value` to the transmit buffer, where it'll queue up until the buffer is flushed (usually within 100 milliseconds).
-
-Returns the number of bytes that were sent to the BLE central device (0 if there is no BLE central device connected, 1 if there is a BLE central device connected).
-
-### `size_t HardwareBLESerial::print(int64_t value)`, `size_t HardwareBLESerial::println(int64_t value)`
-
-Writes a single signed 64-bit integer `value` to the transmit buffer, formatted as a decimal number, where it'll queue up until the buffer is flushed (usually within 100 milliseconds).
-
-Returns the number of bytes that were sent to the BLE central device (0 if there is no BLE central device connected).
-
-### `size_t HardwareBLESerial::print(uint64_t value)`, `size_t HardwareBLESerial::println(uint64_t value)`
-
-Writes a single unsigned 64-bit integer `value` to the transmit buffer, formatted as a non-negative decimal number, where it'll queue up until the buffer is flushed (usually within 100 milliseconds).
-
-Returns the number of bytes that were sent to the BLE central device (0 if there is no BLE central device connected).
-
-### `size_t HardwareBLESerial::print(double value)`, `size_t HardwareBLESerial::println(double value)`
-
-Writes a single double `value` to the transmit buffer, formatted as a decimal format floating point number (i.e., no exponents), where it'll queue up until the buffer is flushed (usually within 100 milliseconds).
-
-Returns the number of bytes that were sent to the BLE central device (0 if there is no BLE central device connected).
+default arduino Print class is implemented
 
 ### `if (HardwareBLESerial) { ... }`
 
@@ -206,6 +182,15 @@ while (!bleSerial) {
   delay(100); // on Mbed-based Arduino boards, delay() makes the board enter a low-power sleep mode
 }
 ```
+
+### `HardwareBLESerialHost &bleSerial = HardwareBLESerialHost::getInstance()`
+
+The `HardwareBLESerialHost` class is a singleton, so there can be at most 1 instance of this class (because a device can only have 1 UART service).
+
+The `getInstance` method returns a reference to this singular instance of `HardwareBLESerialHost`.
+
+The 'host' class was added in 2023 (by some weirdo on the internet), to act as a BLE central and communicate with other microcontrollers. It automatically searches for devices and connects to the first one it finds (for now?). See SerialPassthrough example sketch for implementation.
+
 
 Resources
 ---------

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,22 +1,26 @@
 # Datatypes (KEYWORD1)
-HardwareBLESerial KEYWORD1
+HardwareBLESerial     KEYWORD1
+HardwareBLESerialHost KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-getInstance KEYWORD2
+getInstance      KEYWORD2
 beginAndSetupBLE KEYWORD2
-begin          KEYWORD2
-poll           KEYWORD2
-end            KEYWORD2
-available      KEYWORD2
-peek           KEYWORD2
-read           KEYWORD2
-write          KEYWORD2
-flush          KEYWORD2
-availableLines KEYWORD2
-peekLine       KEYWORD2
-readLine       KEYWORD2
-print          KEYWORD2
-println        KEYWORD2
+begin            KEYWORD2
+poll             KEYWORD2
+end              KEYWORD2
+available        KEYWORD2
+peek             KEYWORD2
+read             KEYWORD2
+write            KEYWORD2
+flush            KEYWORD2
+availableLines   KEYWORD2
+peekLine         KEYWORD2
+readLine         KEYWORD2
+print            KEYWORD2
+println          KEYWORD2
 
 # Constants (LITERAL1)
-BLE_SERIAL_RECEIVE_BUFFER_SIZE LITERAL1
+BLE_SERIAL_RECEIVE_BUFFER_SIZE  LITERAL1
+uartService_UUID                LITERAL1
+receiveCharacteristic_UUID      LITERAL1
+transmitCharacteristic_UUID     LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=HardwareBLESerial
-version=1.0.0
+version=1.0.1
 author=Anthony Zhang (Uberi) <me@anthonyz.ca>
 maintainer=Anthony Zhang (Uberi) <me@anthonyz.ca>
 sentence=An Arduino library for Nordic Semiconductors proprietary UART/Serial Port Emulation over BLE protocol, using ArduinoBLE.

--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -1,10 +1,135 @@
 #include "HardwareBLESerial.h"
 
-HardwareBLESerial::HardwareBLESerial() {
+#ifdef ARDUINO_ARCH_STM32 // NOTE: this may not be as all-inclusive as it should. Works fine for me right now though ;)
+  #if defined(ARDUINO_NUCLEO_WB15CC) || defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK) // just an extra check (for my foolish future-self)
+    HCISharedMemTransportClass HCISharedMemTransport;
+    #if !defined(FAKE_BLELOCALDEVICE)
+      BLELocalDevice BLEObj(&HCISharedMemTransport);
+      BLELocalDevice& BLE = BLEObj; // this is a slight hack, to make the library happy. It's presumably a remnant of the ArduinoBLE library origins
+    #endif
+  #else
+    #error("other STM32 BLE devices (or any devices included the STM32duinoBLE library) are not yet setup in the HardwareBLESerial library.\
+            Please consult the STM32duinoBLE library for the proper setup config")
+  #endif
+#else
+#endif
+
+_HardwareBLESerialBase::_HardwareBLESerialBase() {
   this->numAvailableLines = 0;
   this->transmitBufferLength = 0;
   this->lastFlushTime = 0;
 }
+
+void _HardwareBLESerialBase::poll() {
+  if (millis() - this->lastFlushTime > 100) {
+    flush();
+  } else {
+    BLE.poll();
+  }
+}
+
+void _HardwareBLESerialBase::end() {
+  this->receiveBuffer.clear();
+  flush();
+}
+
+size_t _HardwareBLESerialBase::available() {
+  return this->receiveBuffer.getLength();
+}
+
+int _HardwareBLESerialBase::peek() {
+  if (this->receiveBuffer.getLength() == 0) return -1;
+  return this->receiveBuffer.get(0);
+}
+
+int _HardwareBLESerialBase::read() {
+  int result = this->receiveBuffer.pop();
+  if (result == (int)'\n') {
+    this->numAvailableLines --;
+  }
+  return result;
+}
+
+size_t _HardwareBLESerialBase::write(uint8_t byte) {
+  if (this->_transmitReady() == false) {
+    return 0;
+  }
+  this->transmitBuffer[this->transmitBufferLength] = byte;
+  this->transmitBufferLength ++;
+  if (this->transmitBufferLength == sizeof(this->transmitBuffer)) {
+    flush();
+  }
+  return 1;
+}
+
+size_t _HardwareBLESerialBase::write(uint8_t* buffer, size_t size) { // Thijs addition
+  size_t written = 0;
+  while(written < size) {
+    if(this->_transmitReady() == false) { return(written); } // check connection
+    while((this->transmitBufferLength < sizeof(this->transmitBuffer)) && (written < size)) {
+      this->transmitBuffer[this->transmitBufferLength] = buffer[written]; // copy byte
+      this->transmitBufferLength++; written++; // increment counters
+    }
+    if (this->transmitBufferLength == sizeof(this->transmitBuffer)) { flush(); } // the extra if-statement here just avoids an extra flush of a partially filled buffer
+  }
+  return(written);
+}
+
+size_t _HardwareBLESerialBase::availableLines() {
+  return this->numAvailableLines;
+}
+
+size_t _HardwareBLESerialBase::peekLine(char *buffer, size_t bufferSize) {
+  if (this->availableLines() == 0) {
+    buffer[0] = '\0';
+    return 0;
+  }
+  size_t i = 0;
+  for (; i < bufferSize - 1; i ++) {
+    int chr = this->receiveBuffer.get(i);
+    if (chr == -1 || chr == '\n') {
+      break;
+    } else {
+      buffer[i] = chr;
+    }
+  }
+  buffer[i] = '\0';
+  return i;
+}
+
+size_t _HardwareBLESerialBase::readLine(char *buffer, size_t bufferSize) {
+  if (this->availableLines() == 0) {
+    buffer[0] = '\0';
+    return 0;
+  }
+  size_t i = 0;
+  for (; i < bufferSize - 1; i ++) {
+    int chr = this->read();
+    if (chr == -1 || chr == '\n') {
+      break;
+    } else {
+      buffer[i] = chr;
+    }
+  }
+  buffer[i] = '\0';
+  return i;
+}
+
+_HardwareBLESerialBase::operator bool() {
+  return BLE.connected();
+}
+
+void _HardwareBLESerialBase::onReceive(const uint8_t* data, size_t size) {
+  for (size_t i = 0; i < min(size, sizeof(this->receiveBuffer)); i++) {
+    this->receiveBuffer.add(data[i]);
+    if (data[i] == '\n') {
+      this->numAvailableLines ++;
+    }
+  }
+}
+
+
+/////////////////////////////////////////////////////////////////////////// slave (default) specific: ///////////////////////////////////////////
 
 bool HardwareBLESerial::beginAndSetupBLE(const char *name) {
   if (!BLE.begin()) { return false; }
@@ -23,48 +148,12 @@ void HardwareBLESerial::begin() {
   BLE.addService(uartService);
 }
 
-void HardwareBLESerial::poll() {
-  if (millis() - this->lastFlushTime > 100) {
-    flush();
-  } else {
-    BLE.poll();
-  }
-}
-
 void HardwareBLESerial::end() {
   this->receiveCharacteristic.setEventHandler(BLEWritten, NULL);
-  this->receiveBuffer.clear();
-  flush();
+  _HardwareBLESerialBase::end();
 }
 
-size_t HardwareBLESerial::available() {
-  return this->receiveBuffer.getLength();
-}
-
-int HardwareBLESerial::peek() {
-  if (this->receiveBuffer.getLength() == 0) return -1;
-  return this->receiveBuffer.get(0);
-}
-
-int HardwareBLESerial::read() {
-  int result = this->receiveBuffer.pop();
-  if (result == (int)'\n') {
-    this->numAvailableLines --;
-  }
-  return result;
-}
-
-size_t HardwareBLESerial::write(uint8_t byte) {
-  if (this->transmitCharacteristic.subscribed() == false) {
-    return 0;
-  }
-  this->transmitBuffer[this->transmitBufferLength] = byte;
-  this->transmitBufferLength ++;
-  if (this->transmitBufferLength == sizeof(this->transmitBuffer)) {
-      flush();
-  }
-  return 1;
-}
+bool HardwareBLESerial::_transmitReady() { return(this->transmitCharacteristic.subscribed()); }
 
 void HardwareBLESerial::flush() {
   if (this->transmitBufferLength > 0) {
@@ -75,95 +164,117 @@ void HardwareBLESerial::flush() {
   BLE.poll();
 }
 
-size_t HardwareBLESerial::availableLines() {
-  return this->numAvailableLines;
-}
-
-size_t HardwareBLESerial::peekLine(char *buffer, size_t bufferSize) {
-  if (this->availableLines() == 0) {
-    buffer[0] = '\0';
-    return 0;
-  }
-  size_t i = 0;
-  for (; i < bufferSize - 1; i ++) {
-    int chr = this->receiveBuffer.get(i);
-    if (chr == -1 || chr == '\n') {
-      break;
-    } else {
-      buffer[i] = chr;
-    }
-  }
-  buffer[i] = '\0';
-  return i;
-}
-
-size_t HardwareBLESerial::readLine(char *buffer, size_t bufferSize) {
-  if (this->availableLines() == 0) {
-    buffer[0] = '\0';
-    return 0;
-  }
-  size_t i = 0;
-  for (; i < bufferSize - 1; i ++) {
-    int chr = this->read();
-    if (chr == -1 || chr == '\n') {
-      break;
-    } else {
-      buffer[i] = chr;
-    }
-  }
-  buffer[i] = '\0';
-  return i;
-}
-
-size_t HardwareBLESerial::print(const char *str) {
-  if (this->transmitCharacteristic.subscribed() == false) {
-    return 0;
-  }
-  size_t written = 0;
-  for (size_t i = 0; str[i] != '\0'; i ++) {
-    written += this->write(str[i]);
-  }
-  return written;
-}
-size_t HardwareBLESerial::println(const char *str) { return this->print(str) + this->write('\n'); }
-
-size_t HardwareBLESerial::print(char value) {
-  char buf[2] = { value, '\0' };
-  return this->print(buf);
-}
-size_t HardwareBLESerial::println(char value) { return this->print(value) + this->write('\n'); }
-
-size_t HardwareBLESerial::print(int64_t value) {
-  char buf[21]; snprintf(buf, 21, "%lld", value); // the longest representation of a uint64_t is for -2^63, 20 characters plus null terminator
-  return this->print(buf);
-}
-size_t HardwareBLESerial::println(int64_t value) { return this->print(value) + this->write('\n'); }
-
-size_t HardwareBLESerial::print(uint64_t value) {
-  char buf[21]; snprintf(buf, 21, "%llu", value);  // the longest representation of a uint64_t is for 2^64-1, 20 characters plus null terminator
-  return this->print(buf);
-}
-size_t HardwareBLESerial::println(uint64_t value) { return this->print(value) + this->write('\n'); }
-
-size_t HardwareBLESerial::print(double value) {
-  char buf[319]; snprintf(buf, 319, "%f", value); // the longest representation of a double is for -1e308, 318 characters plus null terminator
-  return this->print(buf);
-}
-size_t HardwareBLESerial::println(double value) { return this->print(value) + this->write('\n'); }
-
-HardwareBLESerial::operator bool() {
-  return BLE.connected();
-}
-
-void HardwareBLESerial::onReceive(const uint8_t* data, size_t size) {
-  for (size_t i = 0; i < min(size, sizeof(this->receiveBuffer)); i++) {
-    this->receiveBuffer.add(data[i]);
-    if (data[i] == '\n') {
-      this->numAvailableLines ++;
-    }
-  }
-}
-
 void HardwareBLESerial::onBLEWritten(BLEDevice central, BLECharacteristic characteristic) {
   HardwareBLESerial::getInstance().onReceive(characteristic.value(), characteristic.valueLength());
+}
+
+/////////////////////////////////////////////////////////////////////////// host specific: ///////////////////////////////////////////
+
+bool HardwareBLESerialHost::beginAndSetupBLE(const char *name) {
+  if (!BLE.begin()) { return false; }
+  BLE.setLocalName(name);
+  BLE.setDeviceName(name);
+  BLE.scanForUuid("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); // start looking for BLE devices that advertise the UART service
+  return true;
+  //// TODO:
+  // BLE.setEventHandler(BLEDiscovered, HardwareBLESerialHost::_tryConnect);
+  // BLE.setEventHandler(BLEConnected, HardwareBLESerialHost::_tryConnect);
+  // BLE.setEventHandler(BLEDisconnected, HardwareBLESerialHost::_tryConnect); // (BLEDeviceEvent event, BLEDeviceEventHandler eventHandler)
+}
+
+bool HardwareBLESerialHost::tryConnect() {
+  if(!BLE.connected()) { // if you're already connected, just do nothing
+    if(this->_wasConnected) {
+      this->_wasConnected = false; // only do this once
+      BLE.scanForUuid("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); // start looking for a peripheral again
+      Serial.println("debug disconnected");
+    }
+    this->peripheral = BLE.available();
+    if(this->peripheral) {
+      BLE.stopScan(); // stop looking once a peripheral is found
+      if(_initConnection()) { this->_wasConnected = true; } // try to initialize connection with peripheral
+      else { BLE.scanForUuid("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); } // start looking for a peripheral again
+    }
+  }
+  return(BLE.connected());
+}
+
+
+// void printPeripheralStats(BLEDevice peripheral) { // debug
+//   if(!peripheral.connected()) { Serial.println("perihperal not connected"); return; }
+//   // if(!peripheral.discovered()) { Serial.println("perihperal not discovered"); return; }
+//   //// print all the BLE stuff of the connected device:
+//   Serial.print("serviceCount: "); Serial.println(peripheral.serviceCount());
+//   for(uint8_t i=0; i<peripheral.serviceCount(); i++) {
+//     BLEService service = peripheral.service(i);
+//     Serial.print("service UUID: "); Serial.println(service.uuid());
+//     Serial.print("  characteristicCount: "); Serial.println(service.characteristicCount());
+//     for(uint8_t j=0; j<service.characteristicCount(); j++) {
+//       BLECharacteristic characteristic = service.characteristic(j);
+//       Serial.print("    characteristic UUID: "); Serial.println(characteristic.uuid());
+//       Serial.print("      valueLength: "); Serial.println(characteristic.valueLength());
+//       Serial.print("      valueSize: "); Serial.println(characteristic.valueSize());
+//       Serial.print("      properties: 0b"); Serial.println(characteristic.properties(), BIN);
+//       Serial.print("      canRead: "); Serial.println(characteristic.canRead());
+//       Serial.print("      canWrite: "); Serial.println(characteristic.canWrite());
+//       Serial.print("      canSubscribe: "); Serial.println(characteristic.canSubscribe());
+//       Serial.print("      canUnsubscribe: "); Serial.println(characteristic.canUnsubscribe());
+//       Serial.print("      written: "); Serial.println(characteristic.written());
+//       Serial.print("      descriptorCount: "); Serial.println(characteristic.descriptorCount());
+//       Serial.print("      peripheral hasCharacteristic: "); Serial.println(peripheral.hasCharacteristic(characteristic.uuid()));
+//       Serial.print("      service hasCharacteristic: "); Serial.println(service.hasCharacteristic(characteristic.uuid()));
+//       for(uint8_t k=0; k<characteristic.descriptorCount(); k++) {
+//         BLEDescriptor descriptor = characteristic.descriptor(k);
+//         Serial.print("    descriptor UUID: "); Serial.println(descriptor.uuid());
+//         Serial.print("      valueLength: "); Serial.println(descriptor.valueLength());
+//         Serial.print("      valueSize: "); Serial.println(descriptor.valueSize());
+//       }
+//     }
+//   }
+//   //// NOTE: you can also just get abstract characteristics, instead of going through the classes, but i don't love that
+//   // Serial.print("characteristicCount: "); Serial.println(peripheral.characteristicCount());
+//   // for(uint8_t j=0; j<peripheral.characteristicCount(); j++) {
+//   //   BLECharacteristic characteristic = peripheral.characteristic(j);
+//   //   Serial.print("  characteristic UUID: "); Serial.println(characteristic.uuid());
+//   // }
+// }
+
+
+bool HardwareBLESerialHost::_initConnection() {
+  if(!this->peripheral.connect()) { return(false); } // try connection
+  if(!this->peripheral.discoverAttributes()) { return(false); } // try attribute discovery
+  // printPeripheralStats(this->peripheral); // debug
+  // if(!this->peripheral.hasService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")) { return(false); } // check if it has the attribute (it must, because of the way the scanning works)
+  // BLEService uartService = this->peripheral.service("6E400001-B5A3-F393-E0A9-E50E24DCCA9E"); // temporary object, just for checking whether it has the characteristics
+  // if(!uartService.hasCharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")) { return(false); } // check if it has a receiveCharacteristic
+  this->transmitCharacteristic = this->peripheral.characteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E"); // the slave's receive is this object's transmit
+  if(!this->transmitCharacteristic) { return(false); } // check if characteristic was retrieved
+  if(!this->transmitCharacteristic.canWrite()) { return(false); } // check if the characteristic has the right properties
+  // if(!uartService.hasCharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")) { return(false); } // check if it has a transmitCharacteristic
+  this->receiveCharacteristic = this->peripheral.characteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E"); // the slave's transmit is this object's receive
+  if(!this->receiveCharacteristic) { return(false); } // check if characteristic was retrieved
+  if(!this->receiveCharacteristic.canSubscribe()) { return(false); } // check if the characteristic has the right properties
+  if(!this->receiveCharacteristic.subscribe()) { return(false); } // try subscribe (Note: does not appear to be stricly necessary)
+  this->receiveCharacteristic.setEventHandler(BLEWritten, HardwareBLESerialHost::onBLEWritten); // set the ISR
+  return(this->peripheral.connected()); // if it made it here, the the connection is good
+}
+
+void HardwareBLESerialHost::end() {
+  this->receiveCharacteristic.setEventHandler(BLEWritten, NULL);
+  _HardwareBLESerialBase::end();
+}
+
+bool HardwareBLESerialHost::_transmitReady() { return(BLE.connected()); } // always true???? (no need to subscribe)
+
+void HardwareBLESerialHost::flush() {
+  if (this->transmitBufferLength > 0) {
+    this->transmitCharacteristic.setValue(this->transmitBuffer, this->transmitBufferLength);
+    this->transmitBufferLength = 0;
+  }
+  this->lastFlushTime = millis();
+  BLE.poll();
+}
+
+void HardwareBLESerialHost::onBLEWritten(BLEDevice periph, BLECharacteristic characteristic) {
+  HardwareBLESerialHost::getInstance().onReceive(characteristic.value(), characteristic.valueLength());
 }

--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -217,7 +217,7 @@ bool HardwareBLESerialHost::beginAndSetupBLE(const char *name) {
 
 bool HardwareBLESerialHost::_initConnection(BLEDevice periph) {
   this->peripheral = periph;
-  if(!this->peripheral.connect()) { Serial.println("debug never connected"); BLE.scanForUuid(uartService_UUID); return(false); } // try connection (NOTE: subject to debugging)
+  if(!this->peripheral.connect()) { /* Serial.println("debug never connected"); */ BLE.scanForUuid(uartService_UUID); return(false); } // try connection (NOTE: subject to debugging)
   if(!this->peripheral.discoverAttributes()) { this->peripheral.disconnect(); return(false); } // try attribute discovery
   // printPeripheralStats(this->peripheral); // debug
   // //// verify whether it has the right services and characteristics (before retrieving them)
@@ -252,7 +252,7 @@ void HardwareBLESerialHost::onBLEDiscovered(BLEDevice periph) {
 
 void HardwareBLESerialHost::onBLEDisconnected(BLEDevice periph) {
   BLE.scanForUuid(uartService_UUID); // start looking for a peripheral again
-  Serial.println("debug disconnected");
+  // Serial.println("debug disconnected"); // see "debug never connected" (i want to see whether the Disconnect eventHandler is called if connect() fails)
 }
 
 // void HardwareBLESerialHost::onBLEConnected(BLEDevice periph) { // not needed (for now?)

--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -1,5 +1,21 @@
 #include "HardwareBLESerial.h"
 
+//// Thijs addition:
+#ifdef ARDUINO_ARCH_STM32 // NOTE: this may not be as all-inclusive as it should. Works fine for me right now though ;)
+  #if defined(ARDUINO_NUCLEO_WB15CC) || defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK) // just an extra check (for my foolish future-self)
+    HCISharedMemTransportClass HCISharedMemTransport;
+    #if !defined(FAKE_BLELOCALDEVICE)
+      BLELocalDevice BLEObj(&HCISharedMemTransport);
+      BLELocalDevice& BLE = BLEObj; // this is a slight hack, to make the library happy. It's presumably a remnant of the ArduinoBLE library origins
+    #endif
+  #else
+    #error("other STM32 BLE devices (or any devices included the STM32duinoBLE library) are not yet setup in the HardwareBLESerial library.\
+            Please consult the STM32duinoBLE library for the proper setup config")
+  #endif
+#else
+#endif
+//// end of Thijs addition
+
 HardwareBLESerial::HardwareBLESerial() {
   this->numAvailableLines = 0;
   this->transmitBufferLength = 0;

--- a/src/HardwareBLESerial.cpp
+++ b/src/HardwareBLESerial.cpp
@@ -2,11 +2,12 @@
 
 #ifdef ARDUINO_ARCH_STM32 // NOTE: this may not be as all-inclusive as it should. Works fine for me right now though ;)
   #if defined(ARDUINO_NUCLEO_WB15CC) || defined(ARDUINO_P_NUCLEO_WB55RG) || defined(ARDUINO_STM32WB5MM_DK) // just an extra check (for my foolish future-self)
-    HCISharedMemTransportClass HCISharedMemTransport;
-    #if !defined(FAKE_BLELOCALDEVICE)
-      BLELocalDevice BLEObj(&HCISharedMemTransport);
-      BLELocalDevice& BLE = BLEObj; // this is a slight hack, to make the library happy. It's presumably a remnant of the ArduinoBLE library origins
-    #endif
+    // HCISharedMemTransportClass HCISharedMemTransport;
+    // #if !defined(FAKE_BLELOCALDEVICE)
+    //   BLELocalDevice BLEObj(&HCISharedMemTransport);
+    //   BLELocalDevice& BLE = BLEObj; // this is a slight hack, to make the library happy. It's presumably a remnant of the ArduinoBLE library origins
+    // #endif
+    //// commented out, because it's no longer needed with recent version of STM32duinoBLE (?)
   #else
     #error("other STM32 BLE devices (or any devices included the STM32duinoBLE library) are not yet setup in the HardwareBLESerial library.\
             Please consult the STM32duinoBLE library for the proper setup config")

--- a/src/HardwareBLESerial.h
+++ b/src/HardwareBLESerial.h
@@ -6,6 +6,15 @@ An Arduino library for Nordic Semiconductors' proprietary "UART/Serial Port Emul
 * https://github.com/sandeepmistry/arduino-BLEPeripheral/tree/master/examples/serial
 
 Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://apps.apple.com/at/app/adafruit-bluefruit-le-connect/id830125974).
+
+modified by Thijs van Liempd in July of 2023
+I added STM32 compatibility (using the STM32duinoBLE library, which is function-compatible, so it's a very minor change)
+I used the Arduino Print class as a base (removing the manual implementations of print() and adding a write(buf,len) function) and changed a few things
+I added a host class to enable communication between microcontrollers (tested on STM32WB55's using the STM32duinoBLE library) (Note: the base-class implementation is not the cleanest)
+TODO:
+- selecting which peripheral to connect to when playing host (instead of just selecting the first one found)
+- multiple peripherals (multiple serials) in host mode???? (not sure whether it's possible, but it sounds fun)
+- cleaner code (the base class could be cleaner)
 */
 
 #ifndef __BLE_SERIAL_H__
@@ -13,7 +22,6 @@ Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://app
 
 #include <Arduino.h>
 
-//// Thijs addition/change:
 #ifdef ARDUINO_ARCH_STM32 // NOTE: this may not be as all-inclusive as it should. Works fine for me right now though ;)
   // #include "app_conf_custom.h" // should be done in main.cpp instead (before importing this library)
   #include <STM32duinoBLE.h>
@@ -21,10 +29,13 @@ Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://app
 #else
   #include <ArduinoBLE.h>
 #endif
-//// end of Thijs addition/change
 
 #define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 20
 #define BLE_SERIAL_RECEIVE_BUFFER_SIZE 256
+
+const static char* uartService_UUID = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
+const static char* receiveCharacteristic_UUID = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
+const static char* transmitCharacteristic_UUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E";
 
 template<size_t N> class ByteRingBuffer {
   private:
@@ -69,7 +80,7 @@ class _HardwareBLESerialBase : public Print {
     size_t write(uint8_t byte);
     using Print::write; // pull in write(str) from Print
     size_t write(uint8_t* buffer, size_t size);
-    virtual void flush() = 0;
+    void flush();
 
     size_t availableLines();
     size_t peekLine(char *buffer, size_t bufferSize);
@@ -95,6 +106,9 @@ class _HardwareBLESerialBase : public Print {
     // virtual BLECharacteristic transmitCharacteristic;
 
     void onReceive(const uint8_t* data, size_t size);
+
+    BLECharacteristic receiveCharacteristic = BLECharacteristic(receiveCharacteristic_UUID, BLEWriteWithoutResponse, BLE_ATTRIBUTE_MAX_VALUE_LENGTH);
+    BLECharacteristic transmitCharacteristic = BLECharacteristic(transmitCharacteristic_UUID, BLENotify, BLE_ATTRIBUTE_MAX_VALUE_LENGTH);
 };
 
 /////////////////////////////////////////////////////////////////////////// slave (default) specific: ///////////////////////////////////////////
@@ -106,21 +120,17 @@ class HardwareBLESerial : public _HardwareBLESerialBase {
       static HardwareBLESerial instance; // instantiated on first use, guaranteed to be destroyed
       return instance;
     }
-    // using _HardwareBLESerialBase::_HardwareBLESerialBase; // inherit constructor
 
     // similar to begin(), but also sets up ArduinoBLE for you, which you otherwise have to do manually
     // use this for simplicity, use begin() for flexibility (e.g., more than one service)
     bool beginAndSetupBLE(const char *name);
     void begin();
-    void end();
     bool _transmitReady();
-    void flush();
   private:
     static void onBLEWritten(BLEDevice central, BLECharacteristic characteristic); // i couldn't figure out how to put this in the base class without compiler complaints
 
-    BLEService uartService = BLEService("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
-    BLECharacteristic receiveCharacteristic = BLECharacteristic("6E400002-B5A3-F393-E0A9-E50E24DCCA9E", BLEWriteWithoutResponse, BLE_ATTRIBUTE_MAX_VALUE_LENGTH);
-    BLECharacteristic transmitCharacteristic = BLECharacteristic("6E400003-B5A3-F393-E0A9-E50E24DCCA9E", BLENotify, BLE_ATTRIBUTE_MAX_VALUE_LENGTH);
+    BLEService uartService = BLEService(uartService_UUID);
+    // (characteristics moved to base class)
 };
 
 /////////////////////////////////////////////////////////////////////////// host specific: ///////////////////////////////////////////
@@ -132,27 +142,25 @@ class HardwareBLESerialHost : public _HardwareBLESerialBase {
       static HardwareBLESerialHost instance; // instantiated on first use, guaranteed to be destroyed
       return instance;
     }
-    // using _HardwareBLESerialBase::_HardwareBLESerialBase; // inherit constructor
 
-    // similar to begin(), but also sets up ArduinoBLE for you, which you otherwise have to do manually
-    // use this for simplicity, use begin() for flexibility (e.g., more than one service)
+    // the only begin function (for now?). It may be possible to do multiple things as a central device, but i am weary of getting into those weeds
     bool beginAndSetupBLE(const char *name);
+    // begin() was removed (for now?)
 
-    // volatile bool autoReconnect = false; // TODO
-    bool tryConnect();
-    bool _initConnection();
+    bool _initConnection(BLEDevice periph); // called when a device is discovered
+    bool _transmitReady(); // returns connection status instead of subscription status
 
-    void end();
-    bool _transmitReady();
-    void flush();
-  // private:
-    static void onBLEWritten(BLEDevice periph, BLECharacteristic characteristic); // i couldn't figure out how to put this in the base class without compiler complaints
-
+    // String peripheralAddress() { return(peripheral.address()); } // if the peripheral member below is private/protected, give the user access to the MAC address at least
+  // protected: // nah, i think the user should have access (to retrieve stuff like MAC addresses and such)
     BLEDevice peripheral; // the counterpart device
-    volatile bool _wasConnected = false;
 
-    BLECharacteristic receiveCharacteristic;
-    BLECharacteristic transmitCharacteristic;
+   private:
+    static void onBLEWritten(BLEDevice periph, BLECharacteristic characteristic); // same as original class (but couldn't be part of base class)
+    static void onBLEDiscovered(BLEDevice periph); // when a device is found (through scanning) it will automatically connect
+    static void onBLEDisconnected(BLEDevice periph); // when the peripheral is disconnected, start scanning again
+    // static void onBLEConnected(BLEDevice periph); // not needed (for now?)
+    
+    // (characteristics moved to base class)
 };
 
 #endif

--- a/src/HardwareBLESerial.h
+++ b/src/HardwareBLESerial.h
@@ -12,7 +12,16 @@ Tested using UART console feature in [Adafruit Bluefruit LE Connect](https://app
 #define __BLE_SERIAL_H__
 
 #include <Arduino.h>
-#include <ArduinoBLE.h>
+
+//// Thijs addition/change:
+#ifdef ARDUINO_ARCH_STM32 // NOTE: this may not be as all-inclusive as it should. Works fine for me right now though ;)
+  // #include "app_conf_custom.h" // should be done in main.cpp instead (before importing this library)
+  #include <STM32duinoBLE.h>
+  //// NOTE: some initialization (for compability with ArduinoBLE classes) was also added to the .cpp file
+#else
+  #include <ArduinoBLE.h>
+#endif
+//// end of Thijs addition/change
 
 #define BLE_ATTRIBUTE_MAX_VALUE_LENGTH 20
 #define BLE_SERIAL_RECEIVE_BUFFER_SIZE 256

--- a/src/HardwareBLESerial.h
+++ b/src/HardwareBLESerial.h
@@ -13,6 +13,7 @@ I used the Arduino Print class as a base (removing the manual implementations of
 I added a host class to enable communication between microcontrollers (tested on STM32WB55's using the STM32duinoBLE library) (Note: the base-class implementation is not the cleanest)
 (I updated the SerialPassthrough example to include the new host class)
 TODO:
+- find out why I2C crashes the BLE connection on STM32WB55 (i sincerely doubt it's related to this library)
 - selecting which peripheral to connect to when playing host (instead of just selecting the first one found)
 - multiple peripherals (multiple serials) in host mode???? (not sure whether it's possible, but it sounds fun)
 - cleaner code (the base class could be cleaner)


### PR DESCRIPTION
i wanted to use this nice library for a project using an STM32WB55, which only took a few lines ('STM32duinoBLE library)
then i decided to implement the Arduino Print class inheritance (mostly for fun)
then i needed two STM32WB55's to talk to each other, so i added a host-mode (which is really what prompted me to make this pull-request. I think it's pretty useful to have a simple library for basic 2-way communication between microcontrollers using BLE. It's something i've used BT classic (using an ESP32) for several times).

The code needs a critical eye, probably some reformatting (if you want) and perhaps an update of the README, but it does at least appear to work (on my machine ;) ).
The dependence on the STM32duinoBLE also comes with the requirement of having the right BLE stack flashed, so a reference to those instructions might be wise.
One notable issue i'm still investigating is that BLE and I2C on the STM32WB55 don't seem to mix very well. Long I2C operations can kill the BLE connection, so there's probably an interrupt/subroutine blocker in the I2C code somewhere.